### PR TITLE
Replace xrange with range because xrange is python 2

### DIFF
--- a/lib/rfx_utils.py
+++ b/lib/rfx_utils.py
@@ -69,7 +69,7 @@ def dec2bin(x, width=8):
 	http://stackoverflow.com/questions/187273/base-2-binary-representation-using-python
 	Brian (http://stackoverflow.com/users/9493/brian)
 	"""
-	return ''.join(str((x>>i)&1) for i in xrange(width-1,-1,-1))
+	return ''.join(str((x>>i)&1) for i in range(width-1,-1,-1))
 
 # ----------------------------------------------------------------------------
 


### PR DESCRIPTION
rfxcmd sometimes fails with this error
```
Traceback (most recent call last):
  File "./rfxcmd.py", line 1733, in <module>
    option_listen()
  File "./rfxcmd.py", line 1192, in option_listen
    rawcmd = read_rfx()
  File "./rfxcmd.py", line 951, in read_rfx
    decode_packet(message)
  File "./rfxcmd.py", line 604, in decode_packet
    metadata, output_extra = rfxdecode0x1.decode_0x13(message, subtype, seqnbr)
  File "/opt/rfxcmd/lib/rfx_decode_0x1.py", line 195, in decode_0x13
    code1 = dec2bin(int(ByteToHex(message[4]), 16))
  File "/opt/rfxcmd/lib/rfx_utils.py", line 72, in dec2bin
    return ''.join(str((x>>i)&1) for i in xrange(width-1,-1,-1))
NameError: name 'xrange' is not defined
```

because there is still a trace of python 2 left in this code. This PR fixes that.